### PR TITLE
Bugfix: proper assemblies initialization

### DIFF
--- a/Migrations.EPiServer/MigrationRunnerBuilder.cs
+++ b/Migrations.EPiServer/MigrationRunnerBuilder.cs
@@ -39,7 +39,7 @@ namespace Forte.Migrations.EPiServer
 
         public MigrationRunner Create()
         {
-            var migrationsProvider = ReflectionMigrationProvider.FromAssemblies(this.assemblies ?? context.Assemblies);
+            var migrationsProvider = ReflectionMigrationProvider.FromAssemblies(this.assemblies.Any() ? this.assemblies : context.Assemblies);
 
             var activator = new DecoratingActivator<IMigration>(
                 new ServiceLocatorActivator(this.context.Locate.Advanced),


### PR DESCRIPTION
Since assemblies list is initialized with Enumerable.Empty we cannot use null coalescing operator (as it will always return true/left part of expression)